### PR TITLE
Automatic deploy to GH pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,63 @@
+name: Deploy to GitHub Pages
+
+env:
+  NODE_VERSION: 18
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**/*.mjs'
+
+jobs:
+  build:
+    name: Run benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out to repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run benchmark
+        run: npm run test
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: results
+          path: |
+            ./community.html
+            ./index-minimal.html
+            ./index.html
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    # Write access to the repository is required to deploy to GitHub Pages.
+    permissions:
+      contents: write
+    steps:
+      - name: Check out to repository
+        uses: actions/checkout@v3
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: results
+          path: ./results
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./results


### PR DESCRIPTION
This is an easier way to publish the results, but please keep in mind, _maybe_ the workflow needs _minimal_ correction, I didn't tested it, I just modified one of my existing workflows.

If you merge it, I think you can remove the HTML files (like [this](https://github.com/romainmenke/css-tokenizer-tests/blob/main/community.html)) from version control.

Reference: https://github.com/peaceiris/actions-gh-pages#getting-started
CC @romainmenke 