### PR TITLE
replace \u0000 with \uFFFD in structured output

### DIFF
--- a/tests/fuzz/b69ece36-057f-4450-9423-a1661787bce6/tokens.json
+++ b/tests/fuzz/b69ece36-057f-4450-9423-a1661787bce6/tokens.json
@@ -19,11 +19,11 @@
 	},
 	{
 		"type": "delim-token",
-		"raw": "\u0000",
+		"raw": "\uFFFD",
 		"startIndex": 4,
 		"endIndex": 5,
 		"structured": {
-			"value": "\u0000"
+			"value": "\uFFFD"
 		}
 	},
 	{


### PR DESCRIPTION
This fuzz test `b69ece36-057f-4450-9423-a1661787bce6` uses the null character `\u0000` resulting in the structured output having a delim of `\u0000`, but this is not correct given the [CSS Syntax Module Level 3 specification](https://drafts.csswg.org/css-syntax-3).

> [3.3. Preprocessing the input stream](https://drafts.csswg.org/css-syntax-3/#input-preprocessing)
> 
> The input stream consists of the [filtered code points](https://drafts.csswg.org/css-syntax-3/#css-filter-code-points) pushed into it as the input byte stream is decoded.
> To filter code points from a stream of (unfiltered) [code points](https://infra.spec.whatwg.org/#code-point) input:
> 
>    Replace any U+000D CARRIAGE RETURN (CR) [code points](https://infra.spec.whatwg.org/#code-point), U+000C FORM FEED (FF) code points, or pairs of U+000D CARRIAGE RETURN (CR) followed by U+000A LINE FEED (LF) in input by a single U+000A LINE FEED (LF) code point.
>    Replace any U+0000 NULL or [surrogate](https://infra.spec.whatwg.org/#surrogate) [code points](https://infra.spec.whatwg.org/#code-point) in input with U+FFFD REPLACEMENT CHARACTER (�).

This means whenever a tokenizer encounters `\u0000` it should be re-interpreted as `\uFFFD`. 

This is also specifically called out in "12.6. Changes from CSS 2.1 and Selectors Level 3":

> [12.6. Changes from CSS 2.1 and Selectors Level 3](https://drafts.csswg.org/css-syntax-3/#changes-css21)
> [...]
> Tokenization changes:
>
>    Any U+0000 NULL [code point](https://infra.spec.whatwg.org/#code-point) in the CSS source is replaced with U+FFFD REPLACEMENT CHARACTER.


This PR alters the fuzz test `b69ece36-057f-4450-9423-a1661787bce6` to change the Delim token's structured value from `\u0000` to `\FFFD`.

I discovered this while working on a css parser during this stream: https://youtube.com/live/AXtb9k-iEyY if you want to watch the excruciatingly long discovery :joy: 